### PR TITLE
Add study group list view

### DIFF
--- a/HighTeach/settings.py
+++ b/HighTeach/settings.py
@@ -15,7 +15,6 @@ from pathlib import Path
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
@@ -26,7 +25,6 @@ SECRET_KEY = 'django-insecure-yvf7#03l1eaa1kp26bjh^cvs03q^f!_2cs)*q6yd^*s36#$m#$
 DEBUG = True
 
 ALLOWED_HOSTS = []
-
 
 # Application definition
 
@@ -76,7 +74,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'HighTeach.wsgi.application'
 
-
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
@@ -86,7 +83,6 @@ DATABASES = {
         'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators
@@ -106,7 +102,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/4.1/topics/i18n/
 
@@ -117,7 +112,6 @@ TIME_ZONE = 'UTC'
 USE_I18N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
@@ -133,3 +127,5 @@ STATICFILES_DIRS = [
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 MEDIA_ROOT = BASE_DIR / 'media'
 MEDIA_URL = '/media/'
+
+LOGIN_URL = '/admin'

--- a/main/templates/base_home.html
+++ b/main/templates/base_home.html
@@ -12,6 +12,7 @@
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css">
     <link rel="icon" href="{% static 'images/Lightbulb.png' %}" >
   </head>
   <body>

--- a/main/templates/base_home.html
+++ b/main/templates/base_home.html
@@ -52,4 +52,3 @@
     {% block content %} {% endblock %}
   </body>
 </html>
-

--- a/study_group/forms.py
+++ b/study_group/forms.py
@@ -1,0 +1,22 @@
+from django import forms
+from .models import StudyGroup
+
+
+class StudyGroupCreationForm(forms.ModelForm):
+    class Meta:
+        model = StudyGroup
+        fields = ['field', 'group_description', 'capacity']
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('group_owner', None)
+        super().__init__(*args, **kwargs)
+
+    def save(self, commit=True):
+        new_study_group = super().save(commit=False)
+        new_study_group.group_owner = self.user
+
+        if commit:
+            new_study_group.save()
+
+        new_study_group.join_group(self.user)
+        return new_study_group

--- a/study_group/templates/study_group_detail.html
+++ b/study_group/templates/study_group_detail.html
@@ -32,6 +32,7 @@
             <div class="mb-3">
                 <h4 class="card-title">Group Members</h4>
             </div>
+        </div>
 
         <div class="input-group rounded">
           <input type="search" class="form-control rounded" placeholder="Search" aria-label="Search" aria-describedby="search-addon" />

--- a/study_group/templates/study_group_hub.html
+++ b/study_group/templates/study_group_hub.html
@@ -1,0 +1,25 @@
+{% extends 'main/loggedInPage.html' %}
+
+{% load study_group_tags %}
+{% load static %}
+
+{% block main_content %}
+    <link rel="stylesheet" type="text/css" href="{% static 'styles/../../static/styles/study_group_stylesheet.css' %}">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8">
+                <h4 class="text-center">My Study Groups</h4>
+                {% include 'users_study_groups.html' %}
+            </div>
+
+            <div class="col border bg-light bg-light mb-4 p-3 shadow-sm border rounded">
+                <h4 class="text-center">Study Group Creation</h4>
+                <form method="post">
+                    {% csrf_token %}
+                    {{ create_study_group_form.as_p }}
+                    <button class="btn btn-secondary" type="submit">Create Group</button>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/study_group/templates/users_study_groups.html
+++ b/study_group/templates/users_study_groups.html
@@ -1,0 +1,32 @@
+{% load study_group_tags %}
+{% load static %}
+
+{% block content %}
+<link rel="stylesheet" type="text/css" href="{% static 'styles/../../static/styles/study_group_stylesheet.css' %}">
+
+<div class="container">
+<div class="row">
+  {% for study_group in study_groups %}
+    <div class="col-md-4">
+      <div class="card bg-light mb-4 box-shadow shadow-sm border rounded">
+        <div class="card-body">
+          <h5 class="card-title card-link"
+              data-bs-toggle="collapse"
+              href="#groupDetails{{ study_group.pk }}"
+              role="button" aria-expanded="false"
+              aria-controls="groupDetails{{ study_group.pk }}">
+            <a href="{% url "study_group_detail" study_group.pk %}">{{ study_group.field }}</a>
+          </h5>
+          <p class="card-text text-truncate">{{ study_group.group_description }}</p>
+        <i class="bi bi-people-fill"></i>
+          <p class="card-text text-muted">{{ study_group|group_members_count_formatted }}</p>
+            {% include 'leave_join_button.html' %}
+        </div>
+      </div>
+    </div>
+  {% empty %}
+    <p>No study groups available.</p>
+  {% endfor %}
+</div>
+</div>
+{% endblock %}

--- a/study_group/templatetags/study_group_tags.py
+++ b/study_group/templatetags/study_group_tags.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter(name='group_members_count_formatted')
+def group_members_count_formatted(study_group):
+    return f"{study_group.members_count}/{study_group.capacity} Members"

--- a/study_group/templatetags/study_group_tags.py
+++ b/study_group/templatetags/study_group_tags.py
@@ -1,8 +1,9 @@
 from django import template
 
+
 register = template.Library()
 
 
 @register.filter(name='group_members_count_formatted')
 def group_members_count_formatted(study_group):
-    return f"{study_group.members_count}/{study_group.capacity} Members"
+    return f"{study_group.get_group_members_count()}/{study_group.capacity} Members"

--- a/study_group/urls.py
+++ b/study_group/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import StudyGroupDetailView, StudyGroupUpdateView, LeaveJoinGroupView
+from .views import StudyGroupDetailView, StudyGroupUpdateView, LeaveJoinGroupView, StudyGroupListView
 
 urlpatterns = [
     path('detail/<int:pk>/', StudyGroupDetailView.as_view(), name="study_group_detail"),
     path('update/<int:pk>/', StudyGroupUpdateView.as_view(), name="study_group_update"),
+    path('list/', StudyGroupListView.as_view(), name="study_groups_list_for_user"),
     path('join_leave/<int:pk>/', LeaveJoinGroupView.as_view(), name="leave_or_join_group"),
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,12 +213,6 @@ def image_file():
 
 
 @pytest.fixture
-def authorized_client(client, persist_user):
-    client.force_login(persist_user)
-    return client
-
-
-@pytest.fixture
 def make_study_group_of_varied_size():
     def _make_study_group_of_varied_size(group_members_num, max_capacity):
         new_group = StudyGroup(
@@ -258,3 +252,9 @@ def persist_review(new_review):
 def persist_review_number_two(new_review_two):
     new_review_two.save()
     return new_review_two
+
+
+@pytest.fixture
+def authorized_client(client, persist_user):
+    client.force_login(persist_user)
+    return client


### PR DESCRIPTION
This PR adds a page that displays all users groups and a form to create a new group. As follows:
- Add bootstrap icons to `base_home.html`,  Add LOGIN_URL project settings. in order to redirect to login when unauthorized, in views that inherit from `LoginRequiredMixin` 
----
- Add templatetags to be used in `study_group` app
- Create view `StudyGroupListView` for displaying list of study groups using `study_group.html` and `study_group_hub.html` templates. And a model form to create new group. 
- Add tests for views. 
- Register URLs to study_group app urls, and include study_group app urls to project url
----
TODO:
- Add link from each study group card to study group detail
----

dependencies:
#75 , #82, #86 (All merged)
resolves: #88 

----
Screenshots:
![study_group_list](https://github.com/redhat-beyond/HighTeach/assets/83830531/4c8e2bd0-b3ef-4bc2-8904-8006f8aedbc1)

