### PR TITLE
Add Study group detail view

### DIFF
--- a/HighTeach/urls.py
+++ b/HighTeach/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from main import views
 from django.contrib.auth import views as auth_views
 
@@ -22,4 +22,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', views.homePage, name='homePage'),
     path('logout/', auth_views.LogoutView.as_view(template_name='main/homePage.html'), name='logout'),
+    path('study-group/', include('study_group.urls')),
 ]

--- a/main/templates/main/loggedInPage.html
+++ b/main/templates/main/loggedInPage.html
@@ -25,7 +25,10 @@
               <li><i class="fa fa-comments icon4"></i><a class="noDecoration" href="#">Messages</a></li>
               <li><i class="fa fa-sharp fa-regular fa-graduation-cap"></i><a class="noDecoration" href="#">My Courses</a></li>
             {% if user.profile.account_type == 'S' %}
-              <li><i class="fa fa-users icon2"></i><a class="noDecoration" href="#">Study Groups</a></li>
+              <li>
+                  <i class="fa fa-users icon2"></i>
+                  <a class="noDecoration" href="/study-group/list/">Study Groups</a>
+              </li>
             {% endif %}
             </ul>
         </div>

--- a/static/styles/study_group_stylesheet.css
+++ b/static/styles/study_group_stylesheet.css
@@ -1,0 +1,9 @@
+h2, h4, a {
+  color: #2E8B57;
+}
+
+.list-group-item {
+  background-color: rgba(238, 238, 238, 0.62);
+  border: none;
+  color: #555555;
+}

--- a/study_group/templates/leave_join_button.html
+++ b/study_group/templates/leave_join_button.html
@@ -1,0 +1,10 @@
+<form action="{% url "leave_or_join_group" study_group.pk %}" method="post">
+{% csrf_token %}
+  {% if request.user in study_group.get_all_group_members %}
+      <button type="submit" class="btn btn-secondary">Leave Group</button>
+  {% elif study_group.is_group_full %}
+      <button type="submit" class="btn btn-secondary" disabled>Group Full</button>
+  {% else %}
+      <button type="submit" class="btn btn-success">Join Group</button>
+  {% endif %}
+</form>

--- a/study_group/templates/study_group_detail.html
+++ b/study_group/templates/study_group_detail.html
@@ -1,0 +1,53 @@
+{% extends 'main/loggedInPage.html' %}
+
+{% load static %}
+
+{% block main_content %}
+  <link rel="stylesheet" type="text/css" href="{% static 'styles/study_group_stylesheet.css' %}">
+
+    <div class="container">
+    <div class="row">
+      <div class="col-lg-6">
+        <div class="chat-placeholder bg-light mb-4 p-3 shadow-sm border rounded">
+          <h4 class="card-title">Chat</h4>
+        </div>
+      </div>
+
+      <div class="col-lg-4">
+          <div class="member-card bg-light mb-4 p-3 shadow-sm border rounded">
+            <h2 class="mt-4">{{ study_group.field }}</h2>
+            <p>{{ study_group.group_description }}</p>
+              {% if study_group.group_owner == request.user %}
+                  <a href="{% url "study_group_update" study_group.pk %}">
+                      <div class="d-flex align-items-center">
+                          <i class="bi bi-pencil-square"></i>
+                          <p>Edit Group info</p>
+                      </div>
+                  </a>
+              {% endif %}
+                {% include "leave_join_button.html" %}
+          </div>
+
+        <div class="member-card bg-light mb-4 p-3 shadow-sm border rounded">
+            <div class="mb-3">
+                <h4 class="card-title">Group Members</h4>
+            </div>
+
+        <div class="input-group rounded">
+          <input type="search" class="form-control rounded" placeholder="Search" aria-label="Search" aria-describedby="search-addon" />
+          <span class="input-group-text border-0" id="search-addon">
+            <i class="fas fa-search"></i>
+          </span>
+        </div>
+          <div class="member-list rounded">
+            <ul class="list-group">
+              {% for member in study_group.get_all_group_members %}
+                <li class="list-group-item">{{ member.username }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/study_group/templates/study_group_update.html
+++ b/study_group/templates/study_group_update.html
@@ -1,0 +1,16 @@
+{% extends 'main/loggedInPage.html' %}
+
+{% load static %}
+
+{% block main_content %}
+    <link rel="stylesheet" type="text/css" href="{% static 'styles/study_group_stylesheet.css' %}">
+    <div class="bg-light border">
+        <h4>Edit study group details</h4>
+        <form method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <input type="submit" value="Update">
+        </form>
+    </div>
+
+{% endblock %}

--- a/study_group/urls.py
+++ b/study_group/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from .views import StudyGroupDetailView, StudyGroupUpdateView, LeaveJoinGroupView
+
+urlpatterns = [
+    path('detail/<int:pk>/', StudyGroupDetailView.as_view(), name="study_group_detail"),
+    path('update/<int:pk>/', StudyGroupUpdateView.as_view(), name="study_group_update"),
+    path('join_leave/<int:pk>/', LeaveJoinGroupView.as_view(), name="leave_or_join_group"),
+]

--- a/study_group/views.py
+++ b/study_group/views.py
@@ -1,0 +1,41 @@
+from django.views.generic import DetailView, View
+from django.views.generic.edit import UpdateView
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.urls import reverse_lazy
+from django.shortcuts import get_object_or_404, redirect
+from django.core.exceptions import PermissionDenied
+
+from .models import StudyGroup
+
+
+class StudyGroupDetailView(LoginRequiredMixin, DetailView):
+    model = StudyGroup
+    template_name = "study_group_detail.html"
+    context_object_name = "study_group"
+
+
+class StudyGroupUpdateView(LoginRequiredMixin, UpdateView):
+    model = StudyGroup
+    fields = ["field", "group_description"]
+    template_name = "study_group_update.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        if self.get_object().group_owner != self.request.user:
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_success_url(self):
+        return reverse_lazy("study_group_detail", kwargs={"pk": self.object.pk})
+
+
+class LeaveJoinGroupView(LoginRequiredMixin, View):
+    def post(self, request, pk):
+        group = get_object_or_404(StudyGroup, pk=pk)
+        user = request.user
+
+        if user in group.get_all_group_members():
+            group.leave_group(user)
+        else:
+            group.join_group(user)
+
+        return redirect('study_group_detail', pk)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,28 @@ def image_file():
 
 
 @pytest.fixture
+def authorized_client(client, persist_user):
+    client.force_login(persist_user)
+    return client
+
+
+@pytest.fixture
+def make_study_group_of_varied_size():
+    def _make_study_group_of_varied_size(group_members_num, max_capacity):
+        new_group = StudyGroup(
+            group_owner=User.objects.create(username='group_owner', password='pass'),
+            field="field",
+            group_description="description",
+            capacity=max_capacity)
+        new_group.save()
+        for i in range(group_members_num):
+            new_group.join_group((User.objects.create(username=f'user{i}', password='pass')))
+        return new_group
+
+    return _make_study_group_of_varied_size
+
+
+@pytest.fixture
 def new_review(persist_second_user, persist_course):
     review = Review(student=persist_second_user, course=persist_course,
                     rating=1, content="Greate course", date=date(2023, 4, 17))

--- a/tests/study_group/test_study_group.py
+++ b/tests/study_group/test_study_group.py
@@ -1,24 +1,8 @@
 import pytest
-from study_group.models import StudyGroup, GroupMember
+from study_group.models import GroupMember
 from django.contrib.auth.models import User
 from django.db.utils import IntegrityError
 from django.core.exceptions import ValidationError
-
-
-@pytest.fixture
-def make_study_group_of_varied_size():
-    def _make_study_group_of_varied_size(group_members_num, max_capacity):
-        new_group = StudyGroup(
-            group_owner=User.objects.create(username='group_owner', password='pass'),
-            field="field",
-            group_description="description",
-            capacity=max_capacity)
-        new_group.save()
-        for i in range(group_members_num):
-            new_group.join_group((User.objects.create(username=f'user{i}', password='pass')))
-        return new_group
-
-    return _make_study_group_of_varied_size
 
 
 @pytest.mark.django_db

--- a/tests/study_group/test_study_group_views.py
+++ b/tests/study_group/test_study_group_views.py
@@ -1,0 +1,78 @@
+import pytest
+
+from study_group.models import StudyGroup
+
+
+@pytest.mark.django_db
+class TestStudyGroupDetailView:
+    def test_study_group_detail_view_loaded_authorized(self, authorized_client, persist_group):
+        study_group_list_response = authorized_client.get(f"/study-group/detail/{persist_group.pk}/")
+        assert study_group_list_response.status_code == 200
+
+    def test_study_group_detail_view_loaded_unauthorized(self, client, persist_group):
+        study_group_list_response = client.get(f"/study-group/detail/{persist_group.pk}/")
+        assert study_group_list_response.status_code == 302
+
+    @pytest.mark.parametrize("new_field, new_desc", [("new field", "this is a new group description")])
+    def test_edit_group_details_not_owner(self, make_study_group_of_varied_size, authorized_client, new_field,
+                                          new_desc):
+        group_not_owner_of = make_study_group_of_varied_size(1, 5)
+        response = authorized_client.post(f"/study-group/update/{group_not_owner_of.pk}/",
+                                          {"field": new_field, "group_description": new_desc})
+        assert response.status_code == 403
+
+    def test_display_edit_group_when_owner(self, client, persist_user, persist_group):
+        client.force_login(persist_user)
+        response = client.get(f"/study-group/detail/{persist_group.pk}/")
+        assert b"Edit Group info" in response.content
+
+    def test_not_display_edit_group_when_not_owner(self, client, persist_second_user, persist_group):
+        client.force_login(persist_second_user)
+        response = client.get(f"/study-group/detail/{persist_group.pk}/")
+        assert b"Edit Group info" not in response.content
+
+
+@pytest.mark.django_db
+class TestJoinLeaveGroupButton:
+    def test_leave_group(self, client, persist_user, persist_group):
+        client.force_login(persist_user)
+        persist_group.join_group(persist_user)
+        assert persist_group.is_user_in_group(persist_user)
+
+        post_response = client.post(f"/study-group/join_leave/{persist_group.pk}/")
+
+        assert post_response.status_code == 302
+        assert not persist_group.is_user_in_group(persist_user)
+
+    def test_join_group(self, client, persist_user, persist_group):
+        client.force_login(persist_user)
+        assert not persist_group.is_user_in_group(persist_user)
+
+        post_response = client.post(f"/study-group/join_leave/{persist_group.pk}/")
+
+        assert post_response.status_code == 302
+        assert persist_group.is_user_in_group(persist_user)
+
+    @pytest.mark.parametrize("non_full, capacity", [(0, 5)])
+    def test_join_group_button_text(self, make_study_group_of_varied_size, authorized_client,
+                                    non_full, capacity):
+        non_empty_group = make_study_group_of_varied_size(non_full, capacity)
+        response = authorized_client.get(f"/study-group/detail/{non_empty_group.pk}/")
+        assert b"Join Group" in response.content
+
+    @pytest.mark.parametrize("full, capacity", [(1, 1)])
+    def test_full_group_button_text(self, make_study_group_of_varied_size, authorized_client,
+                                    full, capacity):
+        non_empty_group = make_study_group_of_varied_size(full, capacity)
+        response = authorized_client.get(f"/study-group/detail/{non_empty_group.pk}/")
+        assert b"Group Full" in response.content
+
+    @pytest.mark.parametrize("num_of_members, capacity", [(1, 2)])
+    def test_leave_group_text_button(self, make_study_group_of_varied_size, num_of_members, capacity,
+                                     persist_user, client):
+        study_group = make_study_group_of_varied_size(num_of_members, capacity)
+        study_group.join_group(persist_user)
+
+        client.force_login(persist_user)
+        response = client.get(f"/study-group/detail/{study_group.pk}/")
+        assert b"Leave Group" in response.content

--- a/tests/study_group/test_study_group_views.py
+++ b/tests/study_group/test_study_group_views.py
@@ -1,4 +1,5 @@
 import pytest
+from django.urls import reverse
 
 from study_group.models import StudyGroup
 
@@ -6,20 +7,13 @@ from study_group.models import StudyGroup
 @pytest.mark.django_db
 class TestStudyGroupDetailView:
     def test_study_group_detail_view_loaded_authorized(self, authorized_client, persist_group):
-        study_group_list_response = authorized_client.get(f"/study-group/detail/{persist_group.pk}/")
-        assert study_group_list_response.status_code == 200
+        group_detail_response = authorized_client.get(f"/study-group/detail/{persist_group.pk}/")
+        assert group_detail_response.status_code == 200
+        assert 'study_group_detail.html' in group_detail_response.templates[0].name
 
     def test_study_group_detail_view_loaded_unauthorized(self, client, persist_group):
         study_group_list_response = client.get(f"/study-group/detail/{persist_group.pk}/")
         assert study_group_list_response.status_code == 302
-
-    @pytest.mark.parametrize("new_field, new_desc", [("new field", "this is a new group description")])
-    def test_edit_group_details_not_owner(self, make_study_group_of_varied_size, authorized_client, new_field,
-                                          new_desc):
-        group_not_owner_of = make_study_group_of_varied_size(1, 5)
-        response = authorized_client.post(f"/study-group/update/{group_not_owner_of.pk}/",
-                                          {"field": new_field, "group_description": new_desc})
-        assert response.status_code == 403
 
     def test_display_edit_group_when_owner(self, client, persist_user, persist_group):
         client.force_login(persist_user)
@@ -33,6 +27,22 @@ class TestStudyGroupDetailView:
 
 
 @pytest.mark.django_db
+class TestStudyGroupUpdateView:
+    def test_study_group_update_view_loaded_authorized(self, authorized_client, persist_group):
+        group_detail_response = authorized_client.get(f"/study-group/update/{persist_group.pk}/")
+        assert group_detail_response.status_code == 200
+        assert 'study_group_update.html' in group_detail_response.templates[0].name
+
+    @pytest.mark.parametrize("new_field, new_desc", [("new field", "this is a new group description")])
+    def test_update_group_details_not_owner(self, make_study_group_of_varied_size, authorized_client, new_field,
+                                            new_desc):
+        group_not_owner_of = make_study_group_of_varied_size(1, 5)
+        response = authorized_client.post(f"/study-group/update/{group_not_owner_of.pk}/",
+                                          {"field": new_field, "group_description": new_desc})
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
 class TestJoinLeaveGroupButton:
     def test_leave_group(self, client, persist_user, persist_group):
         client.force_login(persist_user)
@@ -42,6 +52,7 @@ class TestJoinLeaveGroupButton:
         post_response = client.post(f"/study-group/join_leave/{persist_group.pk}/")
 
         assert post_response.status_code == 302
+        assert post_response.url == reverse("study_group_detail", kwargs={"pk": persist_group.pk})
         assert not persist_group.is_user_in_group(persist_user)
 
     def test_join_group(self, client, persist_user, persist_group):
@@ -51,7 +62,14 @@ class TestJoinLeaveGroupButton:
         post_response = client.post(f"/study-group/join_leave/{persist_group.pk}/")
 
         assert post_response.status_code == 302
+        assert post_response.url == reverse("study_group_detail", kwargs={"pk": persist_group.pk})
         assert persist_group.is_user_in_group(persist_user)
+
+    def test_join_leave_non_existent_group(self, authorized_client, persist_group):
+        StudyGroup.objects.get(pk=persist_group.pk).delete()
+        post_response = authorized_client.post(f"/study-group/join_leave/{persist_group.pk}/")
+
+        assert post_response.status_code == 404
 
     @pytest.mark.parametrize("non_full, capacity", [(0, 5)])
     def test_join_group_button_text(self, make_study_group_of_varied_size, authorized_client,


### PR DESCRIPTION
Adds UI for study group detail page, as follows:

- Create `StudyGroupDetailView` and respective html file `study_group.html`, to display details of a given study group, and interact with it (join, leave, or edit group info if owner).
a Full group cannot be joined (join button will be disabled)
- Create `StudyGroupUpdateView` and respective html file `study_group_update.html` to edit study group info for group owners. 
- Register URLs to study_group app urls, and include study_group app urls to project url
----

dependencies: #75 , #82 (All merged)
resolves #87 

----
Screenshots:
<img width="962" alt="study_group_list" src="https://github.com/redhat-beyond/HighTeach/assets/83830531/e6af0b91-1e37-4e64-84ce-6f539e9dedaa">
![study_group_update](https://github.com/redhat-beyond/HighTeach/assets/83830531/54517204-9e1e-491f-a4d9-9bc2e8487027)



