### PR TITLE
Add display user HTML document

### DIFF
--- a/static/styles/user_list.css
+++ b/static/styles/user_list.css
@@ -1,0 +1,27 @@
+.articles .item {
+    padding: 20px
+}
+
+
+.articles .item .image {
+    min-width: 50px;
+    max-width: 50px;
+    height: 50px;
+    margin-right: 15px
+}
+
+.articles .item img {
+    padding: 3px;
+    border: 1px solid #28a745
+}
+
+.articles .item h3 {
+    color: #555;
+    font-weight: 400;
+    margin-bottom: 0
+}
+
+.articles .item small {
+    color: #aaa;
+    font-size: 0.75em
+}

--- a/study_group/templates/study_group_detail.html
+++ b/study_group/templates/study_group_detail.html
@@ -7,13 +7,13 @@
 
     <div class="container">
     <div class="row">
-      <div class="col-lg-6">
+      <div class="col">
         <div class="chat-placeholder bg-light mb-4 p-3 shadow-sm border rounded">
           <h4 class="card-title">Chat</h4>
         </div>
       </div>
 
-      <div class="col-lg-4">
+      <div class="col-lg-6">
           <div class="member-card bg-light mb-4 p-3 shadow-sm border rounded">
             <h2 class="mt-4">{{ study_group.field }}</h2>
             <p>{{ study_group.group_description }}</p>
@@ -32,8 +32,6 @@
             <div class="mb-3">
                 <h4 class="card-title">Group Members</h4>
             </div>
-        </div>
-
         <div class="input-group rounded">
           <input type="search" class="form-control rounded" placeholder="Search" aria-label="Search" aria-describedby="search-addon" />
           <span class="input-group-text border-0" id="search-addon">
@@ -41,11 +39,13 @@
           </span>
         </div>
           <div class="member-list rounded">
-            <ul class="list-group">
-              {% for member in study_group.get_all_group_members %}
-                <li class="list-group-item">{{ member.username }}</li>
-              {% endfor %}
-            </ul>
+              <div class="articles">
+                  {% for user in study_group.get_all_group_members %}
+                      <div class="card-body no-padding">
+                        {% include "one_user.html" %}
+                      </div>
+                  {% endfor %}
+              </div>
           </div>
         </div>
       </div>

--- a/users/templates/one_user.html
+++ b/users/templates/one_user.html
@@ -1,0 +1,25 @@
+{% load static %}
+{% block content %}
+  <link rel="stylesheet" type="text/css" href="{% static 'styles/user_list.css' %}">
+    <div class="item d-flex align-items-center border rounded bg-white">
+            <div class="image">
+                {% if user.profile.image %}
+                    <img src="{{ user.profile.image }}" alt="Profile Picture" class="img-fluid rounded-circle">
+                {% else %}
+                    <img src="{% static "images/blank_profile.png" %}" alt="Profile Picture" class="img-fluid rounded-circle">
+                {% endif %}
+            </div>
+            <div class="text">
+                <a href="#"><h3 class="h5">{{ user.get_username }}</h3></a>
+                <small>{{ user.get_full_name}}</small>
+            </div>
+        <div class="item">
+            {% if user.profile.account_type == 'T' or user.profile.account_type == 'B' %}
+                <span class="badge rounded-pill bg-success"><i class="bi bi-lightbulb"></i>Teacher</span>
+            {% endif %}
+            {% if user.profile.account_type == 'S' or  user.profile.account_type == 'B' %}
+            <span class="badge rounded-pill bg-success"><i class="bi bi-pencil-fill"></i>Student</span>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
The purpose of this PR is to add a template to standardize display of users across the app
In particular to be used when displaying users in a Study Group detail page and in Search (upcoming PR).

----
The PR introduced the changes as follows:
- Added `one_user.html` and respective stylesheet to `user` app
- Modified study group detail view to use said template

Resolves #109 

----
Screenshot of new template being used in study group detail page:
<img width="959" alt="user_display_in_group_detail" src="https://github.com/redhat-beyond/HighTeach/assets/83830531/9f59aa0c-d31a-42c5-baf9-caec9a411cca">

before:
<img width="962" alt="study_group_list" src="https://github.com/redhat-beyond/HighTeach/assets/83830531/e6af0b91-1e37-4e64-84ce-6f539e9dedaa">